### PR TITLE
Fix/Caspar 2.2 and 2.3 compatibility

### DIFF
--- a/src/imageProvider.ts
+++ b/src/imageProvider.ts
@@ -53,6 +53,7 @@ export class ImageProvider {
 	private frameCounter = 0
 
 	private wasDisconnected: boolean = false
+	private versionBelow220: boolean = false
 
 	constructor () {
 		console.log(`Connecting to CasparCG at ${config.casparHost}, port ${config.casparPort}...`)
@@ -71,6 +72,7 @@ export class ImageProvider {
 	}
 
 	async init () {
+		await this.checkVersion()
 
 		const casparConfig = await this.casparcg.infoConfig()
 
@@ -236,11 +238,15 @@ export class ImageProvider {
 				console.log(`Cannot remove consumer ${myStream.channel}-${streamProducerId}.`)
 			}
 
+			const params = this.versionBelow220 ?
+				`-f mpjpeg -multiple_requests 1 -qmin ${qmin} -qmax ${qmax}` :
+				`-format mpjpeg -multiple_requests 1 -qmin:v ${qmin} -qmax:v ${qmax}`
+
 			await this.casparcg.do(
 				new AMCP.CustomCommand({
 					channel: myStream.channel,
 					command: (
-						`ADD ${myStream.channel}-${streamProducerId} STREAM http://127.0.0.1:${config.port}/feed/${myStream.id} -f mpjpeg -multiple_requests 1 -qmin ${qmin} -qmax ${qmax}`
+						`ADD ${myStream.channel}-${streamProducerId} STREAM http://127.0.0.1:${config.port}/feed/${myStream.id} ${params}`
 					)
 				})
 			)
@@ -507,6 +513,13 @@ export class ImageProvider {
 				)
 			})
 		)
+	}
+	private async checkVersion () {
+		const versionCommand = await this.casparcg.version()
+		const versionParts = versionCommand.response.data.toString().split('.')
+		if (parseInt(versionParts[0], 10) === 2 && parseInt(versionParts[1], 10) < 2) {
+			this.versionBelow220 = true
+		}
 	}
 }
 interface Region {

--- a/src/imageProvider.ts
+++ b/src/imageProvider.ts
@@ -223,15 +223,18 @@ export class ImageProvider {
 			const qmax = config.stream && config.stream.qmax || 5
 
 			const streamProducerId = 998
-
-			await this.casparcg.do(
-				new AMCP.CustomCommand({
-					channel: myStream.channel,
-					command: (
-						`REMOVE ${myStream.channel}-${streamProducerId}`
-					)
-				})
-			)
+			try {
+				await this.casparcg.do(
+					new AMCP.CustomCommand({
+						channel: myStream.channel,
+						command: (
+							`REMOVE ${myStream.channel}-${streamProducerId}`
+						)
+					})
+				)
+			} catch (e) {
+				console.log(`Cannot remove consumer ${myStream.channel}-${streamProducerId}.`)
+			}
 
 			await this.casparcg.do(
 				new AMCP.CustomCommand({


### PR DESCRIPTION
This PR makes possible to use Image Provider with CasparCG 2.2.0 and higher:

- Previous behavior: Attempt to remove a non-existing consumer when initializing ends with `404 REMOVE FAILED`, which results in rejected promise, that prevents the stream from being set up. 
New behavior: Rejection is handled, stream is set up.
- Parameters that have to be passed to the FFmpeg Consumer via `ADD` changed in 2.2.0. 
New behavior: On initialization, version of Caspar is checked. Different set of parameters is sent for versions 2.2.0 and newer.